### PR TITLE
make past events paginated on /events page

### DIFF
--- a/context/UI/pages/events/index.jade
+++ b/context/UI/pages/events/index.jade
@@ -33,3 +33,16 @@ block content
         .section-nav
           a.btn.pull-left(href='/events/#{pastEvents[i].getUrl()}') Прочети повече
           br.clear
+  - if(pageNumber > 0)
+    a(href="/events/#{pageNumber-1}").btn previous
+  - else
+    a.btn.disabled previous
+  - for(var page = 0; page<pastEventsCount/pastEventsLimit; page++)
+    - if(pageNumber != page)
+      a.btn(href="/events/#{page}") #{page}
+    - else
+      a.btn.disabled #{page}
+  - if(pastEventsCount > pastEvents.length+pageNumber*pastEventsLimit)
+    a(href="/events/#{pageNumber+1}").btn next
+  - else
+    a.btn.disabled next

--- a/context/http/helpers/getAllEvents.js
+++ b/context/http/helpers/getAllEvents.js
@@ -18,12 +18,22 @@ var orderPastRecentDesc = function (events) {
   return _.sortBy(past, sortByStartDateTime).reverse()
 }
 
-module.exports = function(req, res, next) {
-  Event.find({}).populate("creator").sort({startDateTime: -1}).exec(function(err, events){
-    if(err) return next(err);
-    res.locals.events = events;
-    res.locals.eventsUpcomingOrder = orderUpcomingFirstDesc(events)
-    res.locals.pastEvents = orderPastRecentDesc(events)
-    next();
-  })
+module.exports = function (pageNumberParamName, limit) {
+  return function(req, res, next) {
+    var pageNumber = req.params[pageNumberParamName]?parseInt(req.params[pageNumberParamName]):0
+    var skip = pageNumber*limit
+    Event.find({}).populate("creator")
+      .sort({startDateTime: -1})
+      .exec(function(err, events){
+        if(err) return next(err);
+        res.locals.events = events;
+        res.locals.eventsUpcomingOrder = orderUpcomingFirstDesc(events)
+        res.locals.pastEvents = orderPastRecentDesc(events)
+        res.locals.pastEventsCount = res.locals.pastEvents.length
+        res.locals.pastEvents = res.locals.pastEvents.splice(skip, limit)
+        res.locals.pastEventsLimit = limit
+        res.locals.pageNumber = pageNumber
+        next();
+      })
+  }
 }

--- a/context/http/pages/events/index.js
+++ b/context/http/pages/events/index.js
@@ -1,6 +1,6 @@
 module.exports = function(plasma, dna, helpers){
   return {
-    "GET": [helpers.getAllEvents, helpers.eventsCount, function(req, res){
+    "GET /:pageNumber?": [helpers.getAllEvents("pageNumber", 6), helpers.eventsCount, function(req, res){
       res.locals.eventsCount = res.locals.events.length;
       res.sendPage("events/index");
     }],


### PR DESCRIPTION
Simple as that. Made possible by cloning the code from /blogs page and implemented pagination only for past events.