### PR TITLE
Updates/fix contact links

### DIFF
--- a/context/UI/pages/index.jade
+++ b/context/UI/pages/index.jade
@@ -1,5 +1,5 @@
 extends layout
 
 block content
-  include ./partials/home/blog-posts
   include ./partials/home/event-posts
+  include ./partials/home/blog-posts

--- a/context/UI/pages/static/contact.jade
+++ b/context/UI/pages/static/contact.jade
@@ -4,6 +4,10 @@ block content
   section.contacts
     .row
       dl
+        dt.vl-term Wiki
+        dd.vl-def.text
+          a(href="https://wiki.varnalab.org") wiki.varnalab.org
+
         dt.vl-term Github
         dd.vl-def.text
           a(href="https://github.com/VarnaLab/varnalab.org") github.com/VarnaLab


### PR DESCRIPTION
# Copyright Updates

1. Swap blog posts and events on the index page
  ![screenshot from 2017-09-13 22-16-07](https://user-images.githubusercontent.com/5685544/30396106-295f6c4e-98d1-11e7-828c-9c5e2ef145d0.png)

2. Add wiki link in `contacts` page
  ![screenshot from 2017-09-13 22-16-43](https://user-images.githubusercontent.com/5685544/30396119-3bfc2810-98d1-11e7-807d-5b16f4a4b7d8.png)


